### PR TITLE
Add barbershop imagery to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,32 @@
     nav .menu a:hover { color: var(--text); }
     .button { display:inline-block; padding:12px 20px; background: var(--brand); color:#111; border-radius:12px; font-weight:700; text-decoration:none; transition: opacity .15s; }
     .button:hover { opacity: 0.9; }
-    .hero { min-height: 80vh; display:flex; align-items:center; justify-content:center; text-align:center; padding: 80px 20px; background: radial-gradient(circle at center, rgba(212,161,88,0.05) 0%, rgba(12,12,15,1) 100%); }
-    .hero .content { background: rgba(0,0,0,0.6); padding: 40px; border-radius: 16px; }
+    .hero {
+      position: relative;
+      isolation: isolate;
+      min-height: 80vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 80px 20px;
+      background: url("https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=2000&q=80") center/cover no-repeat;
+    }
+    .hero::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(12,12,15,0.78), rgba(12,12,15,0.92));
+      z-index: -1;
+    }
+    .hero .content {
+      background: rgba(0,0,0,0.55);
+      padding: 40px;
+      border-radius: 16px;
+      backdrop-filter: blur(6px);
+      box-shadow: 0 20px 40px rgba(0,0,0,0.35);
+      max-width: 600px;
+    }
     .hero h1 { font-size: 42px; margin-bottom:12px; }
     .hero p { font-size:20px; margin-bottom:24px; color: var(--subtext); }
     section { padding: 80px 20px; border-top:1px solid #1a1a22; }
@@ -41,7 +65,23 @@
     .gallery-grid img { width:100%; height:160px; object-fit:cover; border-radius:12px; }
     .team-grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(200px,1fr)); gap:20px; margin-top:40px; }
     .team-member { text-align:center; }
-    .team-member img { width:100%; height:240px; object-fit:cover; border-radius:50%; margin-bottom:12px; border:4px solid var(--brand); }
+    .team-member .avatar {
+      width: 100%;
+      max-width: 240px;
+      aspect-ratio: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 12px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, rgba(212,161,88,0.45), rgba(21,21,27,0.95));
+      border: 4px solid var(--brand);
+      font-size: 48px;
+      font-weight: 800;
+      color: var(--text);
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
     .team-member h4 { margin-bottom:4px; font-size:20px; }
     .team-member span { color: var(--subtext); font-size:14px; }
     .contact-info { text-align:center; margin-top:24px; }
@@ -76,25 +116,25 @@
       <h2>Unsere Services</h2>
       <div class="services-grid">
         <div class="service-card">
-          <img src="images/service-haircut.jpg" alt="Haarschnitt">
+          <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=800&q=80" alt="Barbier arbeitet an einem modernen Fade im Next Level Barbershop" loading="lazy">
           <h3>Haarschnitt</h3>
           <p>Präziser Schnitt und modernes Styling.</p>
           <div class="price">ab 25 €</div>
         </div>
         <div class="service-card">
-          <img src="images/service-beard.jpg" alt="Bartpflege">
+          <img src="https://images.unsplash.com/photo-1517832207067-4db24a2ae47c?auto=format&fit=crop&w=800&q=80" alt="Bartpflege im Premium-Barbershop mit warmem Licht" loading="lazy">
           <h3>Bartpflege</h3>
           <p>Pflege, Konturieren und Styling für deinen Bart.</p>
           <div class="price">ab 12 €</div>
         </div>
         <div class="service-card">
-          <img src="images/service-kids.jpg" alt="Kinderhaarschnitt">
+          <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=800&q=80" alt="Freundliche Atmosphäre für Kinderhaarschnitte im Barbershop" loading="lazy">
           <h3>Kinderhaarschnitt</h3>
           <p>Sanfter und stylischer Haarschnitt für Kinder.</p>
           <div class="price">ab 15 €</div>
         </div>
         <div class="service-card">
-          <img src="images/service-special.jpg" alt="Spezialpakete">
+          <img src="https://images.unsplash.com/photo-1512690459411-b9245b9f04bb?auto=format&fit=crop&w=800&q=80" alt="Detailreiche Rasurstation für exklusive Spezialpakete" loading="lazy">
           <h3>Spezialpakete</h3>
           <p>Kombinationen aus Schnitt, Rasur und Pflege.</p>
           <div class="price">ab 40 €</div>
@@ -106,12 +146,9 @@
     <div class="container">
       <h2>Galerie</h2>
       <div class="gallery-grid">
-        <img src="images/gallery1.jpg" alt="">
-        <img src="images/gallery2.jpg" alt="">
-        <img src="images/gallery3.jpg" alt="">
-        <img src="images/gallery4.jpg" alt="">
-        <img src="images/gallery5.jpg" alt="">
-        <img src="images/gallery6.jpg" alt="">
+        <img src="https://images.unsplash.com/photo-1519744792095-2f2205e87b6f?auto=format&fit=crop&w=700&q=80" alt="Atmosphärischer Blick in den Next Level Barbershop" loading="lazy">
+        <img src="https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=700&q=80" alt="Barbier bereitet Werkzeuge auf einer Arbeitsstation vor" loading="lazy">
+        <img src="https://images.unsplash.com/photo-1582095133179-bfd08e2fc6b3?auto=format&fit=crop&w=700&q=80" alt="Gestylter Arbeitsplatz mit professionellen Barber-Tools" loading="lazy">
       </div>
     </div>
   </section>
@@ -120,17 +157,17 @@
       <h2>Unser Team</h2>
       <div class="team-grid">
         <div class="team-member">
-          <img src="images/barber1.jpg" alt="Mitarbeiter 1">
+          <div class="avatar">S</div>
           <h4>Shirwan</h4>
           <span>Master Barber</span>
         </div>
         <div class="team-member">
-          <img src="images/barber2.jpg" alt="Mitarbeiter 2">
+          <div class="avatar">K2</div>
           <h4>Kollege 2</h4>
           <span>Barber</span>
         </div>
         <div class="team-member">
-          <img src="images/barber3.jpg" alt="Mitarbeiter 3">
+          <div class="avatar">K3</div>
           <h4>Kollege 3</h4>
           <span>Barber</span>
         </div>


### PR DESCRIPTION
## Summary
- load the landing page hero, services and gallery imagery from hosted sources so the site has photos without local binaries
- replace the missing team headshots with styled avatar placeholders so the section keeps its layout
- remove the committed binary photo assets in favor of the remote sources to keep the repository free of binaries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c88e42010c8328b65c98ee6260829d