### PR TITLE
Refresh landing and booking pages with local imagery

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -6,13 +6,13 @@
   <title>Next Level Barbershop – Termin buchen</title>
   <style>
     :root {
-      /* Colour palette for dark theme */
-      --bg: #0c0c0f;
-      --card: #15151b;
-      --muted: #1e1e26;
+      --bg: #040406;
+      --card: rgba(16, 16, 24, 0.8);
+      --muted: rgba(18, 18, 28, 0.8);
       --brand: #d4a158;
-      --text: #f2f2f7;
-      --subtext: #a9a9b3;
+      --accent: #52c1ff;
+      --text: #f5f5f9;
+      --subtext: #a7a7bb;
       --ok: #2ecc71;
     }
     * {
@@ -20,224 +20,316 @@
     }
     html, body {
       margin: 0;
+    }
+    body {
       background: var(--bg);
       color: var(--text);
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+      line-height: 1.6;
     }
-    img { max-width: 100%; display: block; }
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: -2;
+      background-size: cover;
+      background-position: center;
+      opacity: 0.32;
+      filter: saturate(0.7) brightness(0.7);
+    }
+    body::before {
+      background-image: linear-gradient(120deg, rgba(4, 4, 6, 0.65), rgba(4, 4, 6, 0.92)), url("img/background/IMG_6749.jpeg");
+    }
+    body::after {
+      z-index: -3;
+      opacity: 0.22;
+      mix-blend-mode: screen;
+      background-image: radial-gradient(circle at 18% 24%, rgba(82, 193, 255, 0.28), transparent 55%), url("img/background/temp_image_19538764-4E52-4AB7-842A-04A77E9B7881.webp");
+    }
+    img { max-width: 100%; display: block; border-radius: 16px; }
     a { color: inherit; text-decoration: none; }
     nav {
       position: sticky;
       top: 0;
       width: 100%;
       z-index: 50;
-      background: rgba(12,12,15,0.8);
-      backdrop-filter: blur(8px);
-      border-bottom: 1px solid #222;
+      background: rgba(6, 6, 12, 0.72);
+      backdrop-filter: blur(14px);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
     }
     nav .row {
+      max-width: 1100px;
+      margin: 0 auto;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 12px 24px;
+      padding: 16px 24px;
+      gap: 20px;
+      letter-spacing: 0.08em;
     }
     .brand {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 12px;
       font-weight: 700;
+      text-transform: uppercase;
     }
     .brand .dot {
-      width: 12px;
-      height: 12px;
+      width: 14px;
+      height: 14px;
       border-radius: 50%;
-      background: var(--brand);
+      background: linear-gradient(135deg, var(--brand), #f3c27d);
+      box-shadow: 0 0 14px rgba(212, 161, 88, 0.55);
     }
     .menu {
       display: flex;
       gap: 18px;
+      text-transform: uppercase;
+      font-size: 13px;
     }
     .menu a {
       color: var(--subtext);
       font-weight: 600;
-      transition: color 0.15s;
+      transition: color 0.2s ease, opacity 0.2s ease;
     }
     .menu a:hover {
       color: var(--text);
+      opacity: 0.85;
+    }
+    main {
+      padding: 60px 20px 120px;
     }
     .container {
       max-width: 1100px;
       margin: 0 auto;
-      padding: 24px;
+      position: relative;
+      z-index: 1;
+      padding: 48px;
+      border-radius: 28px;
+      backdrop-filter: blur(14px);
+      background: rgba(10, 10, 18, 0.52);
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      box-shadow: 0 34px 90px rgba(0, 0, 0, 0.45);
     }
-    /* Hero grid of haircut results */
+    nav .container {
+      padding: 0;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      backdrop-filter: none;
+    }
+    section {
+      position: relative;
+      padding: 70px 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.04);
+    }
+    section::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top right, rgba(82, 193, 255, 0.08), transparent 60%), linear-gradient(200deg, rgba(8, 8, 12, 0.92), rgba(6, 6, 10, 0.88));
+      z-index: -1;
+      opacity: 0.9;
+    }
+    section.intro::before {
+      background: linear-gradient(160deg, rgba(8, 8, 12, 0.88), rgba(12, 12, 18, 0.82)), url("img/background/temp_image_8C66F222-BD9C-4C45-A02B-9CE9C08362B2.webp") center/cover;
+      opacity: 0.38;
+    }
+    h1 {
+      font-size: clamp(2.2rem, 4vw, 3.2rem);
+      margin: 26px 0 12px;
+      letter-spacing: -0.01em;
+    }
+    h2 {
+      font-size: clamp(1.9rem, 3vw, 2.4rem);
+      margin: 0 0 18px;
+    }
+    p.description {
+      color: var(--subtext);
+      margin: 12px 0 30px;
+      max-width: 640px;
+    }
     .hero-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-      gap: 8px;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 14px;
+      margin-bottom: 28px;
     }
     .hero-grid .tile {
-      aspect-ratio: 4/3;
+      position: relative;
+      aspect-ratio: 4 / 3;
       overflow: hidden;
-      border-radius: 16px;
-      background: #111;
+      border-radius: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
     }
     .hero-grid .tile img {
       width: 100%;
       height: 100%;
       object-fit: cover;
-      filter: saturate(1.05);
+      filter: saturate(1.08);
+      transition: transform 0.35s ease;
     }
-    h1 {
-      font-size: 36px;
-      margin: 24px 0 0;
+    .hero-grid .tile:hover img {
+      transform: scale(1.04);
     }
-    h2 {
-      font-size: 28px;
-      margin: 0 0 16px;
+    .booking {
+      background: rgba(12, 12, 20, 0.6);
+      border-radius: 24px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      padding: 36px;
+      box-shadow: 0 26px 70px rgba(0, 0, 0, 0.45);
     }
-    p.description {
-      color: var(--subtext);
-      margin: 8px 0 24px;
-    }
-    /* Section containers */
-    section {
-      padding: 56px 0;
-      border-top: 1px solid #1a1a22;
-    }
-    .grid-4 {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-      gap: 12px;
-    }
-    .card {
-      background: var(--card);
-      border: 1px solid #1f1f27;
-      border-radius: 16px;
-      overflow: hidden;
-    }
-    .card img {
-      height: 220px;
-      width: 100%;
-      object-fit: cover;
-    }
-    .card .pad {
-      padding: 12px;
-    }
-    .badge {
-      display: inline-block;
-      padding: 4px 10px;
-      border-radius: 999px;
-      background: rgba(212,161,88,0.12);
-      color: var(--brand);
-      font-size: 12px;
-      font-weight: 700;
-    }
-    /* Booking stepper */
     .booking h2 {
-      margin-bottom: 24px;
+      margin-bottom: 28px;
     }
     .stepper {
       display: flex;
       gap: 12px;
       flex-wrap: wrap;
-      margin-bottom: 16px;
+      margin-bottom: 24px;
     }
     .step {
       display: flex;
       align-items: center;
-      gap: 8px;
-      padding: 8px 12px;
+      gap: 10px;
+      padding: 10px 16px;
       border-radius: 999px;
-      background: #111;
-      border: 1px solid #1f1f27;
+      background: rgba(18, 18, 26, 0.8);
+      border: 1px solid rgba(255, 255, 255, 0.04);
       color: var(--subtext);
       font-weight: 600;
+      letter-spacing: 0.05em;
+      transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
     }
     .step.active {
-      background: rgba(212,161,88,0.12);
+      background: rgba(212, 161, 88, 0.12);
       color: var(--text);
-      border-color: var(--brand);
+      border-color: rgba(212, 161, 88, 0.55);
     }
     .box-row {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      gap: 16px;
     }
     .box {
-      background: var(--card);
-      border: 1px solid #1f1f27;
-      border-radius: 16px;
-      padding: 20px;
+      background: rgba(18, 18, 28, 0.82);
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      border-radius: 18px;
+      padding: 22px;
       text-align: center;
       cursor: pointer;
-      transition: transform 0.15s, border-color 0.15s;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
     }
     .box:hover {
-      border-color: var(--brand);
-      transform: translateY(-2px);
+      transform: translateY(-4px);
+      border-color: rgba(212, 161, 88, 0.4);
+      box-shadow: 0 20px 44px rgba(0, 0, 0, 0.4);
     }
     .box.selected {
-      outline: 2px solid var(--brand);
+      border-color: rgba(212, 161, 88, 0.6);
+      box-shadow: 0 0 0 2px rgba(212, 161, 88, 0.35);
     }
     .hidden {
       display: none;
     }
-    .input, .button {
+    .input,
+    .button {
       width: 100%;
-      padding: 12px 14px;
-      border-radius: 12px;
-      border: 1px solid #262633;
-      background: #101017;
+      padding: 12px 16px;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      background: rgba(12, 12, 20, 0.78);
       color: var(--text);
       font-size: 16px;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+    .input:focus {
+      outline: none;
+      border-color: rgba(82, 193, 255, 0.6);
+      box-shadow: 0 0 0 2px rgba(82, 193, 255, 0.15);
     }
     .button {
-      background: var(--brand);
-      border-color: var(--brand);
-      color: #111;
+      background: linear-gradient(135deg, var(--brand), #f2c987);
+      border-color: rgba(212, 161, 88, 0.6);
+      color: #120b05;
       font-weight: 800;
       cursor: pointer;
-      transition: opacity 0.15s;
+      letter-spacing: 0.05em;
+      box-shadow: 0 14px 32px rgba(212, 161, 88, 0.28);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
     .button:hover {
-      opacity: 0.9;
+      transform: translateY(-2px);
+      box-shadow: 0 22px 50px rgba(212, 161, 88, 0.38);
     }
     .time-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-      gap: 8px;
+      grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+      gap: 10px;
+      margin-top: 12px;
     }
     .time {
-      padding: 10px;
-      border: 1px solid #262633;
-      border-radius: 10px;
+      padding: 12px 10px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      border-radius: 12px;
       cursor: pointer;
       text-align: center;
-      background: #101017;
+      background: rgba(18, 18, 30, 0.82);
       font-weight: 600;
+      letter-spacing: 0.04em;
+      transition: border-color 0.2s ease, transform 0.2s ease;
     }
     .time:hover {
-      border-color: var(--brand);
+      border-color: rgba(212, 161, 88, 0.45);
+      transform: translateY(-2px);
     }
     .time.selected {
-      background: rgba(212,161,88,0.12);
-      border-color: var(--brand);
+      background: rgba(212, 161, 88, 0.18);
+      border-color: rgba(212, 161, 88, 0.55);
     }
     .help {
       color: var(--subtext);
       font-size: 14px;
     }
     footer {
-      border-top: 1px solid #1a1a22;
-      padding: 32px 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.04);
+      padding: 40px 20px;
       text-align: center;
       color: var(--subtext);
+      background: rgba(6, 6, 12, 0.7);
+      letter-spacing: 0.04em;
     }
     @media (max-width: 900px) {
       .hero-grid { grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); }
-      .grid-4 { grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); }
-      .time-grid { grid-template-columns: repeat(auto-fill, minmax(60px, 1fr)); }
+      .box-row { grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
+      .time-grid { grid-template-columns: repeat(auto-fill, minmax(70px, 1fr)); }
+      .container { padding: 36px 30px; }
+      .booking { padding: 28px; }
+    }
+    @media (max-width: 640px) {
+      nav .row {
+        flex-direction: column;
+        gap: 12px;
+        text-align: center;
+      }
+      .menu {
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+      .container {
+        padding: 26px 20px;
+      }
+      .booking {
+        padding: 24px;
+      }
+      .hero-grid {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      }
     }
   </style>
 </head>
@@ -253,9 +345,19 @@
     </div>
   </nav>
   <main class="container">
+    <section class="intro">
+      <div class="hero-grid">
+        <div class="tile"><img src="img/galerie/IMG_6737.jpeg" alt="Fresh Fade im Next Level Barbershop" loading="lazy"></div>
+        <div class="tile"><img src="img/galerie/IMG_6738.jpeg" alt="Spezialpaket für einen schwarzen Kunden" loading="lazy"></div>
+        <div class="tile"><img src="img/galerie/IMG_6744.jpeg" alt="Bartpflege mit Lockenfokus" loading="lazy"></div>
+        <div class="tile"><img src="img/galerie/IMG_6750.jpeg" alt="Premium Werkzeug-Setup im Barbershop" loading="lazy"></div>
+      </div>
+      <h1>Termin buchen</h1>
+      <p class="description">Sichere dir deinen Spot im Next Level Barbershop – mit wenigen Klicks zum persönlichen Grooming-Upgrade für 2025.</p>
+    </section>
     <!-- Booking section with interactive flow -->
     <section id="booking" class="booking">
-      <h2>Termin buchen</h2>
+      <h2>Dein persönlicher Flow</h2>
       <div class="stepper">
         <div class="step" id="s1">1 · Friseur wählen</div>
         <div class="step" id="s2">2 · Datum</div>

--- a/index.html
+++ b/index.html
@@ -6,89 +6,445 @@
   <title>Next Level Barbershop</title>
   <style>
     :root {
-      --bg: #0c0c0f;
-      --card: #15151b;
-      --muted: #1e1e26;
+      --bg: #040406;
+      --bg-secondary: rgba(12, 12, 19, 0.82);
+      --card: rgba(16, 16, 24, 0.78);
+      --muted: #1f1f2c;
       --brand: #d4a158;
-      --text: #f2f2f7;
-      --subtext: #a9a9b3;
+      --brand-soft: rgba(212, 161, 88, 0.22);
+      --accent: #52c1ff;
+      --text: #f5f5f9;
+      --subtext: #a7a7bb;
+      --glow: rgba(82, 193, 255, 0.2);
     }
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Open Sans,Helvetica Neue,sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
-    nav { position: sticky; top:0; background: rgba(12,12,15,0.8); border-bottom:1px solid #222; z-index:50; }
-    nav .row { max-width:1100px; margin:0 auto; display:flex; align-items:center; justify-content:space-between; padding:16px; }
-    nav .brand { display:flex; align-items:center; gap:10px; font-weight:700; }
-    nav .brand .dot { width:12px; height:12px; background: var(--brand); border-radius:50%; }
-    nav .menu { display:flex; gap:20px; }
-    nav .menu a { color: var(--subtext); font-weight:600; text-decoration:none; transition: color .15s; }
-    nav .menu a:hover { color: var(--text); }
-    .button { display:inline-block; padding:12px 20px; background: var(--brand); color:#111; border-radius:12px; font-weight:700; text-decoration:none; transition: opacity .15s; }
-    .button:hover { opacity: 0.9; }
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+    }
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: -2;
+      opacity: 0.28;
+      background-size: cover;
+      background-position: center;
+      filter: saturate(0.7) brightness(0.65);
+    }
+    body::before {
+      background-image: linear-gradient(120deg, rgba(4, 4, 6, 0.7), rgba(4, 4, 6, 0.9)), url("img/background/IMG_6749.jpeg");
+    }
+    body::after {
+      z-index: -3;
+      mix-blend-mode: screen;
+      opacity: 0.18;
+      background-image: radial-gradient(circle at 20% 20%, rgba(82, 193, 255, 0.32), transparent 52%), url("img/background/temp_image_8C66F222-BD9C-4C45-A02B-9CE9C08362B2.webp");
+      filter: blur(0.5px) saturate(0.9);
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(16px);
+      background: rgba(6, 6, 12, 0.68);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+    nav .row {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 18px 20px;
+    }
+    nav .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    nav .brand .dot {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, var(--brand), #f3c27d);
+      box-shadow: 0 0 12px rgba(212, 161, 88, 0.55);
+    }
+    nav .menu {
+      display: flex;
+      gap: 22px;
+      font-size: 14px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    nav .menu a {
+      color: var(--subtext);
+      font-weight: 600;
+      text-decoration: none;
+      transition: color 0.2s, opacity 0.2s;
+    }
+    nav .menu a:hover {
+      color: var(--text);
+      opacity: 0.9;
+    }
+    .button {
+      display: inline-block;
+      padding: 12px 22px;
+      background: linear-gradient(135deg, var(--brand), #f2c987);
+      color: #120b05;
+      border-radius: 14px;
+      font-weight: 700;
+      text-decoration: none;
+      letter-spacing: 0.05em;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 12px 24px rgba(212, 161, 88, 0.25);
+    }
+    .button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 18px 38px rgba(212, 161, 88, 0.32);
+    }
     .hero {
       position: relative;
       isolation: isolate;
-      min-height: 80vh;
+      min-height: 82vh;
       display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
-      padding: 80px 20px;
-      background: url("https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=2000&q=80") center/cover no-repeat;
+      padding: 100px 20px 120px;
+      background: url("img/background/temp_image_19538764-4E52-4AB7-842A-04A77E9B7881.webp") center/cover no-repeat;
     }
     .hero::before {
       content: "";
       position: absolute;
       inset: 0;
-      background: linear-gradient(180deg, rgba(12,12,15,0.78), rgba(12,12,15,0.92));
+      background: linear-gradient(180deg, rgba(4, 4, 8, 0.25), rgba(4, 4, 8, 0.78) 60%, rgba(4, 4, 8, 0.96));
       z-index: -1;
     }
-    .hero .content {
-      background: rgba(0,0,0,0.55);
-      padding: 40px;
-      border-radius: 16px;
-      backdrop-filter: blur(6px);
-      box-shadow: 0 20px 40px rgba(0,0,0,0.35);
-      max-width: 600px;
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: 8% 10%;
+      z-index: -1;
+      border-radius: 28px;
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      box-shadow: 0 50px 120px rgba(0, 0, 0, 0.55);
+      background: linear-gradient(135deg, rgba(212, 161, 88, 0.12), transparent 60%);
     }
-    .hero h1 { font-size: 42px; margin-bottom:12px; }
-    .hero p { font-size:20px; margin-bottom:24px; color: var(--subtext); }
-    section { padding: 80px 20px; border-top:1px solid #1a1a22; }
-    .container { max-width:1100px; margin:0 auto; }
-    .services-grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(240px,1fr)); gap:20px; margin-top:40px; }
-    .service-card { background: var(--card); padding:24px; border-radius:16px; border:1px solid #1f1f27; text-align:center; transition: transform .15s, border-color .15s; }
-    .service-card:hover { transform: translateY(-2px); border-color: var(--brand); }
-    .service-card img { height: 160px; width:100%; object-fit: cover; border-radius:12px; margin-bottom:12px; }
-    .service-card h3 { margin-bottom:8px; font-size:24px; }
-    .service-card p { color: var(--subtext); margin-bottom:8px; }
-    .service-card .price { font-weight:700; color: var(--brand); margin-bottom:12px; }
-    .gallery-grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(160px,1fr)); gap:8px; }
-    .gallery-grid img { width:100%; height:160px; object-fit:cover; border-radius:12px; }
-    .team-grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(200px,1fr)); gap:20px; margin-top:40px; }
-    .team-member { text-align:center; }
-    .team-member .avatar {
+    .hero .content {
+      background: rgba(8, 8, 14, 0.62);
+      padding: 48px;
+      border-radius: 24px;
+      backdrop-filter: blur(18px);
+      box-shadow: 0 40px 100px rgba(0, 0, 0, 0.45);
+      max-width: 640px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+    .hero .pretitle {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      background: rgba(82, 193, 255, 0.1);
+      color: #c7e7ff;
+      padding: 8px 16px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      margin-bottom: 18px;
+    }
+    .hero h1 {
+      font-size: clamp(2.5rem, 6vw, 4rem);
+      margin-bottom: 14px;
+      font-weight: 800;
+      letter-spacing: -0.01em;
+    }
+    .hero p {
+      font-size: 1.2rem;
+      margin-bottom: 28px;
+      color: var(--subtext);
+    }
+    .hero .hero-badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      justify-content: center;
+      margin-bottom: 28px;
+    }
+    .hero .hero-badges span {
+      padding: 8px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(212, 161, 88, 0.45);
+      background: rgba(212, 161, 88, 0.08);
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.09em;
+    }
+    section {
+      position: relative;
+      padding: 96px 20px;
+      border-top: 1px solid rgba(255, 255, 255, 0.04);
+      overflow: hidden;
+    }
+    section::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top right, rgba(82, 193, 255, 0.08), transparent 55%), linear-gradient(160deg, rgba(14, 14, 22, 0.86), rgba(7, 7, 12, 0.88));
+      opacity: 0.9;
+      z-index: -1;
+    }
+    #services::before {
+      background: linear-gradient(160deg, rgba(12, 12, 18, 0.9), rgba(8, 8, 12, 0.95)), url("img/background/temp_image_9CAA51A3-9DF3-4FEC-9E03-9FA8787956E5.webp") center/cover;
+      opacity: 0.4;
+    }
+    #gallery::before {
+      background: linear-gradient(180deg, rgba(8, 8, 12, 0.94), rgba(8, 8, 14, 0.96)), url("img/background/temp_image_8C66F222-BD9C-4C45-A02B-9CE9C08362B2.webp") center/cover;
+      opacity: 0.45;
+    }
+    #team::before {
+      background: linear-gradient(200deg, rgba(8, 8, 12, 0.92), rgba(12, 12, 18, 0.9)), url("img/background/temp_image_E1EC1C5B-85E6-433A-B069-C595DD057F53.webp") center/cover;
+      opacity: 0.28;
+    }
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+      position: relative;
+      z-index: 1;
+      backdrop-filter: blur(12px);
+      background: rgba(10, 10, 18, 0.48);
+      border: 1px solid rgba(255, 255, 255, 0.03);
+      border-radius: 28px;
+      padding: 48px;
+      box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+    }
+    section#gallery .container,
+    section#contact .container {
+      background: rgba(10, 10, 18, 0.36);
+    }
+    h2 {
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      margin-bottom: 20px;
+      letter-spacing: -0.01em;
+    }
+    .section-intro {
+      color: var(--subtext);
+      max-width: 600px;
+      margin-bottom: 40px;
+    }
+    .services-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 28px;
+    }
+    .service-card {
+      position: relative;
+      background: linear-gradient(200deg, rgba(21, 21, 30, 0.72), rgba(12, 12, 18, 0.92));
+      border-radius: 22px;
+      padding: 22px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      text-align: left;
+      overflow: hidden;
+      transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+    }
+    .service-card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top, rgba(212, 161, 88, 0.28), transparent 60%);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+    .service-card:hover {
+      transform: translateY(-6px);
+      border-color: rgba(212, 161, 88, 0.55);
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+    }
+    .service-card:hover::before {
+      opacity: 1;
+    }
+    .service-card img {
       width: 100%;
-      max-width: 240px;
+      height: 220px;
+      object-fit: cover;
+      border-radius: 18px;
+      margin-bottom: 18px;
+      filter: saturate(1.08);
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+    }
+    .service-card .label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #cdd9ff;
+      background: rgba(82, 193, 255, 0.12);
+      padding: 6px 12px;
+      border-radius: 999px;
+      margin-bottom: 14px;
+    }
+    .service-card h3 {
+      margin-bottom: 10px;
+      font-size: 1.4rem;
+    }
+    .service-card p {
+      color: var(--subtext);
+      margin-bottom: 16px;
+      min-height: 60px;
+    }
+    .service-card .price {
+      font-weight: 700;
+      color: var(--brand);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 18px;
+      margin-top: 36px;
+    }
+    .gallery-grid img {
+      width: 100%;
+      height: 220px;
+      object-fit: cover;
+      border-radius: 20px;
+      transition: transform 0.35s ease, box-shadow 0.35s ease;
+      filter: saturate(1.06);
+      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+    }
+    .gallery-grid img:hover {
+      transform: translateY(-6px) scale(1.02);
+      box-shadow: 0 26px 70px rgba(0, 0, 0, 0.5);
+    }
+    .team-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 28px;
+      margin-top: 36px;
+    }
+    .team-member {
+      text-align: center;
+      padding: 20px;
+      background: rgba(16, 16, 26, 0.6);
+      border-radius: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+    }
+    .team-member .avatar {
+      width: 180px;
       aspect-ratio: 1;
       display: flex;
       align-items: center;
       justify-content: center;
-      margin: 0 auto 12px;
+      margin: 0 auto 16px;
       border-radius: 50%;
-      background: radial-gradient(circle at 30% 30%, rgba(212,161,88,0.45), rgba(21,21,27,0.95));
-      border: 4px solid var(--brand);
-      font-size: 48px;
+      background: radial-gradient(circle at 30% 30%, rgba(212, 161, 88, 0.55), rgba(16, 16, 26, 0.92));
+      border: 4px solid rgba(212, 161, 88, 0.65);
+      font-size: 46px;
       font-weight: 800;
       color: var(--text);
-      text-transform: uppercase;
-      letter-spacing: 2px;
+      letter-spacing: 0.18em;
     }
-    .team-member h4 { margin-bottom:4px; font-size:20px; }
-    .team-member span { color: var(--subtext); font-size:14px; }
-    .contact-info { text-align:center; margin-top:24px; }
-    .contact-info p { margin-bottom:8px; }
-    footer { padding:40px 20px; border-top:1px solid #1a1a22; text-align:center; font-size:14px; color: var(--subtext); }
-    footer a { color: var(--subtext); margin: 0 8px; text-decoration:none; }
-    footer a:hover { color: var(--brand); }
+    .team-member h4 {
+      margin-bottom: 6px;
+      font-size: 1.3rem;
+    }
+    .team-member span {
+      color: var(--subtext);
+      font-size: 0.9rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .contact-info {
+      text-align: center;
+      margin-top: 28px;
+    }
+    .contact-info p {
+      margin-bottom: 10px;
+      color: var(--subtext);
+      font-size: 1rem;
+    }
+    footer {
+      padding: 40px 20px 60px;
+      border-top: 1px solid rgba(255, 255, 255, 0.04);
+      text-align: center;
+      font-size: 0.9rem;
+      color: var(--subtext);
+      background: rgba(6, 6, 12, 0.72);
+      letter-spacing: 0.04em;
+    }
+    footer a {
+      color: var(--subtext);
+      margin: 0 8px;
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+    footer a:hover {
+      color: var(--brand);
+    }
+    @media (max-width: 960px) {
+      nav .menu {
+        gap: 12px;
+        font-size: 12px;
+      }
+      .hero .content {
+        padding: 32px;
+      }
+      .container {
+        padding: 32px 24px;
+      }
+      .service-card p {
+        min-height: auto;
+      }
+      .gallery-grid {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      }
+    }
+    @media (max-width: 640px) {
+      nav .row {
+        flex-direction: column;
+        gap: 12px;
+      }
+      nav .menu {
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .hero {
+        padding: 100px 16px 90px;
+      }
+      .hero .hero-badges {
+        gap: 8px;
+      }
+      .container {
+        padding: 26px;
+      }
+      .service-card {
+        padding: 20px;
+      }
+      .gallery-grid img {
+        height: 180px;
+      }
+      .team-member .avatar {
+        width: 150px;
+      }
+    }
   </style>
 </head>
 <body>
@@ -104,10 +460,16 @@
       </div>
     </div>
   </nav>
-  <header class="hero">
+  <header class="hero" id="hero">
     <div class="content">
-      <h1>Upgrade Your Style</h1>
-      <p>Erlebe premium Herrenfrisuren, Bartpflege und mehr – bei Next Level Barbershop in Linz.</p>
+      <div class="pretitle"><span>2025 Signature Lab</span></div>
+      <h1>Upgrade Your Style Experience</h1>
+      <p>Premium Fades, luxuriöse Bartpflege und Future-Pro Looks – direkt im Next Level Barbershop Linz.</p>
+      <div class="hero-badges">
+        <span>Skin Fade Atelier</span>
+        <span>Luxury Beard Rituals</span>
+        <span>Personal Styling Mapping</span>
+      </div>
       <a href="booking.html" class="button">Termin buchen</a>
     </div>
   </header>
@@ -116,27 +478,31 @@
       <h2>Unsere Services</h2>
       <div class="services-grid">
         <div class="service-card">
-          <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=800&q=80" alt="Barbier arbeitet an einem modernen Fade im Next Level Barbershop" loading="lazy">
+          <span class="label">Signature Fade · 2025</span>
+          <img src="img/galerie/IMG_6743.jpeg" alt="Shirwan verpasst einem Gast einen modernen Fade im Next Level Barbershop" loading="lazy">
           <h3>Haarschnitt</h3>
-          <p>Präziser Schnitt und modernes Styling.</p>
+          <p>Präzise Fades, strukturierte Texturen und personalisierte Stylings – alles abgestimmt auf deinen Look.</p>
           <div class="price">ab 25 €</div>
         </div>
         <div class="service-card">
-          <img src="https://images.unsplash.com/photo-1517832207067-4db24a2ae47c?auto=format&fit=crop&w=800&q=80" alt="Bartpflege im Premium-Barbershop mit warmem Licht" loading="lazy">
+          <span class="label">Beard Lab Rituals</span>
+          <img src="img/galerie/IMG_6744.jpeg" alt="Bartpflege für einen schwarzhaarigen Kunden mit Locken im Next Level Barbershop" loading="lazy">
           <h3>Bartpflege</h3>
-          <p>Pflege, Konturieren und Styling für deinen Bart.</p>
+          <p>Heiße Kompressen, präzise Konturen und nährende Pflege für deinen schwarzhaarigen Lockenbart.</p>
           <div class="price">ab 12 €</div>
         </div>
         <div class="service-card">
-          <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=800&q=80" alt="Freundliche Atmosphäre für Kinderhaarschnitte im Barbershop" loading="lazy">
+          <span class="label">Kids Chill Zone</span>
+          <img src="img/galerie/IMG_6742.jpeg" alt="Stylischer Kids-Cut in entspannter Atmosphäre des Barbershops" loading="lazy">
           <h3>Kinderhaarschnitt</h3>
-          <p>Sanfter und stylischer Haarschnitt für Kinder.</p>
+          <p>Geduldige Betreuung, kreative Styles und Good-Vibes für die jüngsten Next Level Gäste.</p>
           <div class="price">ab 15 €</div>
         </div>
         <div class="service-card">
-          <img src="https://images.unsplash.com/photo-1512690459411-b9245b9f04bb?auto=format&fit=crop&w=800&q=80" alt="Detailreiche Rasurstation für exklusive Spezialpakete" loading="lazy">
+          <span class="label">VIP Spezialpakete</span>
+          <img src="img/galerie/IMG_6738.jpeg" alt="Schwarzer Stammkunde genießt ein Premium-Spezialpaket im Barbershop" loading="lazy">
           <h3>Spezialpakete</h3>
-          <p>Kombinationen aus Schnitt, Rasur und Pflege.</p>
+          <p>Custom-Kombinationen aus Schnitt, Rasur, Pflege und Styling – ideal für deinen ganz persönlichen Upgrade-Moment.</p>
           <div class="price">ab 40 €</div>
         </div>
       </div>
@@ -145,10 +511,16 @@
   <section id="gallery">
     <div class="container">
       <h2>Galerie</h2>
+      <p class="section-intro">Authentische Einblicke aus unserem Linzer Studio – echte Kunden, echte Skills und unsere Leidenschaft für Details.</p>
       <div class="gallery-grid">
-        <img src="https://images.unsplash.com/photo-1519744792095-2f2205e87b6f?auto=format&fit=crop&w=700&q=80" alt="Atmosphärischer Blick in den Next Level Barbershop" loading="lazy">
-        <img src="https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=700&q=80" alt="Barbier bereitet Werkzeuge auf einer Arbeitsstation vor" loading="lazy">
-        <img src="https://images.unsplash.com/photo-1582095133179-bfd08e2fc6b3?auto=format&fit=crop&w=700&q=80" alt="Gestylter Arbeitsplatz mit professionellen Barber-Tools" loading="lazy">
+        <img src="img/galerie/IMG_6737.jpeg" alt="Shirwan arbeitet fokussiert an einem frischen Fade im Next Level Barbershop" loading="lazy">
+        <img src="img/galerie/IMG_6738.jpeg" alt="Porträt eines schwarzen Kunden nach einem Spezialpaket im Next Level Barbershop" loading="lazy">
+        <img src="img/galerie/IMG_6739.jpeg" alt="Detailaufnahme eines stylischen Fade-Cuts mit Spiegelmoment" loading="lazy">
+        <img src="img/galerie/IMG_6741.jpeg" alt="Moderne Tools und präzise Linienführung im Barbershop" loading="lazy">
+        <img src="img/galerie/IMG_6742.jpeg" alt="Gemeinsamer Moment im Shop mit jungen Gästen nach dem Haarschnitt" loading="lazy">
+        <img src="img/galerie/IMG_6743.jpeg" alt="Barbier-Team beim Finetuning eines Haarschnitts" loading="lazy">
+        <img src="img/galerie/IMG_6744.jpeg" alt="Bartpflege-Session mit einem Kunden mit lockigem Haar" loading="lazy">
+        <img src="img/galerie/IMG_6750.jpeg" alt="Premium-Arbeitsplatz mit Next Level Werkzeug-Setup" loading="lazy">
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- restyle the landing hero and section containers with 2025-ready gradients, glassmorphism and local background photography
- swap service cards and the gallery to use the provided barbershop images with updated copy for fades, beard rituals, kids cuts and VIP bundles
- align the booking flow with the refreshed visual language, adding a local-image hero grid and upgraded stepper, cards and inputs

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9e9126df48328a8211a3cc4b6a1b0